### PR TITLE
Hotfix/fix single image width

### DIFF
--- a/src/pages/MapPage/components/TagDetailDrawer/DetailPart.js
+++ b/src/pages/MapPage/components/TagDetailDrawer/DetailPart.js
@@ -101,21 +101,50 @@ const DetailPart = (props) => {
               />
             ) : (
               tagDetail.imageUrl.map((url) => {
-                return (
-                  <Button
-                    key={url}
-                    onClick={() => setLargeImg(`${url}`)}
-                    style={{
-                      width: '100%',
-                      flexShrink: '0',
-                      overflowY: 'hidden',
-                      backgroundSize: 'cover',
-                      backgroundPosition: 'center',
-                      backgroundImage: `url(${url})`
-                    }}
-                  />
-                )
+                if (tagDetail.imageUrl.length===1) {
+                  return (
+                    <Button
+                      key={url}
+                      onClick={() => setLargeImg(`${url}`)}
+                      style={{
+                        width: '100%',
+                        flexShrink: '0',
+                        overflowY: 'hidden',
+                        backgroundSize: 'cover',
+                        backgroundPosition: 'center',
+                        backgroundImage: `url(${url})`
+                      }}
+                    />
+                  )
+                } else {
+                  return (
+                    <Button
+                      key={url}
+                      onClick={() => setLargeImg(`${url}`)}
+                      style={{
+                        width: '80%',
+                        flexShrink: '0',
+                        overflowY: 'hidden',
+                        backgroundSize: 'cover',
+                        backgroundPosition: 'center',
+                        backgroundImage: `url(${url})`
+                      }}
+                    />
+                  ) 
+                }
               })
+            )}
+            {tagDetail.imageUrl.length === 1 && (
+              <div
+                style={{
+                  width: '80%',
+                  flexShrink: '0',
+                  overflow: 'hidden',
+                  backgroundSize: 'cover',
+                  backgroundPosition: 'center',
+                  backgroundImage: `url(${noImage})`
+                }}
+              />
             )}
           </div>
           <Box

--- a/src/pages/MapPage/components/TagDetailDrawer/DetailPart.js
+++ b/src/pages/MapPage/components/TagDetailDrawer/DetailPart.js
@@ -106,7 +106,7 @@ const DetailPart = (props) => {
                     key={url}
                     onClick={() => setLargeImg(`${url}`)}
                     style={{
-                      width: '80%',
+                      width: '100%',
                       flexShrink: '0',
                       overflowY: 'hidden',
                       backgroundSize: 'cover',
@@ -116,18 +116,6 @@ const DetailPart = (props) => {
                   />
                 )
               })
-            )}
-            {tagDetail.imageUrl.length === 1 && (
-              <div
-                style={{
-                  width: '80%',
-                  flexShrink: '0',
-                  overflow: 'hidden',
-                  backgroundSize: 'cover',
-                  backgroundPosition: 'center',
-                  backgroundImage: `url(${noImage})`
-                }}
-              />
             )}
           </div>
           <Box

--- a/src/pages/MapPage/components/TagDetailDrawer/DetailPart.js
+++ b/src/pages/MapPage/components/TagDetailDrawer/DetailPart.js
@@ -134,18 +134,6 @@ const DetailPart = (props) => {
                 }
               })
             )}
-            {tagDetail.imageUrl.length === 1 && (
-              <div
-                style={{
-                  width: '80%',
-                  flexShrink: '0',
-                  overflow: 'hidden',
-                  backgroundSize: 'cover',
-                  backgroundPosition: 'center',
-                  backgroundImage: `url(${noImage})`
-                }}
-              />
-            )}
           </div>
           <Box
             display='flex'


### PR DESCRIPTION
## Why do we need this PR?
* This PR deletes no-image when at least one image is presented.
* When showing one image, the image width will fill the screen; when showing more than one image, the image width will be 80%.

## How did you address the issue?
*
