### PR TITLE
Add archived tag to the report history. The 檢視 button will be replace…

### DIFF
--- a/src/pages/MapPage/components/ReportHistory/ReportHistory.js
+++ b/src/pages/MapPage/components/ReportHistory/ReportHistory.js
@@ -86,15 +86,25 @@ const ReportHistory = (props) => {
                       </Box>
                     </Grid>
                   </Grid>
-
-                  <CustomButton
-                    buttonType='roundButton_activated'
-                    variant='contained'
-                    size='small'
-                    onClick={() => setActiveTagId(item.id)}
-                  >
-                    檢視
-                  </CustomButton>
+                  {item.archived === true ? (
+                    <CustomButton
+                      buttonType='roundButton_inactivated'
+                      variant='contained'
+                      size='small'
+                      onClick={() => setActiveTagId(item.id)}
+                    >
+                      已封存
+                    </CustomButton>
+                  ) : (
+                    <CustomButton
+                      buttonType='roundButton_activated'
+                      variant='contained'
+                      size='small'
+                      onClick={() => setActiveTagId(item.id)}
+                    >
+                      檢視
+                    </CustomButton>
+                  )}
                 </ListItem>
                 <Divider variant='middle' />
               </div>

--- a/src/utils/hooks/useUserTags.js
+++ b/src/utils/hooks/useUserTags.js
@@ -10,6 +10,7 @@ const GET_USER_TAGS_QUERY = gql`
       tags {
         id
         locationName
+        archived
         category {
           missionName
           subTypeName
@@ -36,6 +37,7 @@ const reformatTagList = (data) => {
     const {
       id,
       locationName,
+      archived,
       category: { missionName, subTypeName, targetName },
       status: { statusName, numberOfUpVote }
     } = tag
@@ -48,6 +50,7 @@ const reformatTagList = (data) => {
     return {
       id,
       locationName,
+      archived,
       category: { missionName, subTypeName, targetName },
       status: { statusName, numberOfUpVote },
       statusHistory


### PR DESCRIPTION
… with 已封存 button in grey.

## Why do we need this PR?
Add archived tags to the tag list in report history. Archived tags will be displayed with "已封存" button in grey.
fix #107 
## How did you address the issue?
*
