### PR TITLE
Fix mobile height bug after rotating

### DIFF
--- a/src/components/CustomDrawer/CustomDrawer.js
+++ b/src/components/CustomDrawer/CustomDrawer.js
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
   },
   drawerContentFull: {
     minHeight: 450,
-    height: 'calc(var(--vh, 1vh) * 100 - 100px)'
+    height: 'calc(100vh - 100px)'
   },
   titleBar: {
     position: 'sticky',

--- a/src/pages/MapPage/components/TagDetailDrawer/TagDetailDrawer.js
+++ b/src/pages/MapPage/components/TagDetailDrawer/TagDetailDrawer.js
@@ -74,7 +74,7 @@ function TagDetailDialog(props) {
         open={deleteDialog}
         PaperProps={{
           style: {
-            background: 'r #FAFAFA',
+            background: '#FAFAFA',
             boxShadow: `0px 2px 4px rgba(0, 0, 0, 0.12), 0px 3px 4px rgba(0, 0, 0, 0.12), 0px 1px 5px rgba(0, 0, 0, 0.2)`,
             borderRadius: `10px`,
             padding: '10px'


### PR DESCRIPTION
## Why do we need this PR?
* Fix mobile tag drawer incorrect height after rotating.

## How did you address the issue?
* Change 100vh definition in calc function.
