### PR TITLE
update node version of CICD to 16

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install Packages
         run: yarn install
       - name: run eslint linter

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Install firebase CLI
         run: npm install -g firebase-tools
       - name: Install Packages

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Install firebase CLI
         run: npm install -g firebase-tools
       - name: Install Packages


### PR DESCRIPTION
## Why do we need this PR?
* Node 14 is not supported in the release of [Firebase CLI v12.0.0](https://github.com/firebase/firebase-tools/releases/tag/v12.0.0).
* This PR updates the node version of CI/CD to 16.

## How did you address the issue?
*
